### PR TITLE
Improvement in the output when using the shortName value for German stocks.

### DIFF
--- a/files/yfquotes@thegli/desklet.js
+++ b/files/yfquotes@thegli/desklet.js
@@ -229,7 +229,7 @@ YahooFinanceQuoteUtils.prototype = {
         } else if (useLongName && this.existsProperty(quote, "longName")) {
             displayName = quote.longName;
         } else if (this.existsProperty(quote, "shortName")) {
-            displayName = quote.shortName;
+            displayName = quote.shortName.split("    ")[0];
         }
 
         quote.displayName = displayName;


### PR DESCRIPTION
You might want to test PSM.DE. Yahoo returns 'ProSiebenSat.1 Media SE         N' as the shortName, which I fix with a single line of code. This improves the display in your Desklet.

However, my improvement does not address the issue when using the long version for the verbose name. The error can also occur there with index names.